### PR TITLE
Publish test results as HTML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         if: always()
         with:
           name: test-results
-          path: './artifacts/test-results/**/*.trx'
+          path: './artifacts/test-results/**/*.html'
           if-no-files-found: error
       - name: Upload coverage report
         uses: actions/upload-artifact@v3

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -94,8 +94,8 @@ class Build : NukeBuild
                         .SetProjectFile(p.TestProject)
                         .SetFramework(p.Framework)
                         .SetResultsDirectory(testResultsDirectory)
-                        .SetLoggers($"trx;LogFileName={testResultsName}.trx");
-                }));
+                        .SetLoggers($"html;LogFileName={testResultsName}.html");
+                }), completeOnFailure: true);
         });
 
     Target GenerateCoverage => _ => _


### PR DESCRIPTION
- Publish test results as HTML
- Continue execution when a combination of test project and framework fails so that we run all tests.