### PR TITLE
Add ability to run integration tests locally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
           dotnet user-secrets set ServiceBusConnection '${{ secrets.SERVICE_BUS_CONNECTION_STRING }}' --id 074ca336-270b-4832-9a1a-60baf152b727
           dotnet user-secrets set APPLICATIONINSIGHTS_CONNECTION_STRING '${{ secrets.APPLICATION_INSIGHTS_CONNECTION_STRING }}' --id 074ca336-270b-4832-9a1a-60baf152b727
       - name: Build
+        id: build
         run: ./build.sh --package
       - name: Upload test results
         uses: actions/upload-artifact@v3
@@ -52,7 +53,7 @@ jobs:
           if-no-files-found: error
       - name: Upload Functions logs
         uses: actions/upload-artifact@v3
-        if: always()
+        if: ${{ failure() && steps.id.conclusion == 'failure' }}
         with:
           name: function-logs
           path: './artifacts/test-results/*.log'

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -70,6 +70,9 @@
           "type": "string",
           "description": "Root directory during build execution"
         },
+        "ServiceBusConnection": {
+          "type": "string"
+        },
         "Skip": {
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+## Integration tests
+
+Before being able to run the integration tests, you'll need to deploy an Application Insights instance and a Service Bus namespace. This can be done using [scripts\testing\deploy-testing.ps1](scripts\testing\deploy-testing.ps1).
+
+Once you have provisioned the infrastructure, write down the Service Bus connection string.
+
+### Running the tests in NUKE
+
+You need to set the Service Bus connection string before running `NUKE`:
+
+```powershell
+$Env:ServiceBusConnection='{connection-string}'
+.\build.ps1
+```
+
+### Running the tests manually
+
+The integration tests rely on both Functions `CustomV4InProcessFunction` and `DefaultV4InProcessFunction` running locally.
+
+Start the custom v4 in-process Function:
+
+```powershell
+cd samples\CustomV4InProcessFunction
+$Env:Testing:IsEnabled='true'
+$Env:ServiceBusConnection='{connection-string}'
+func start
+```
+
+Start the default v4 in-process Function:
+
+```powershell
+cd samples\DefaultV4InProcessFunction
+$Env:Testing:IsEnabled='true'
+$Env:ServiceBusConnection='{connection-string}'
+func start
+```
+
+Run the [integration tests](tests\AzureFunctionsTelemetryIntegrationTests).

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -200,12 +200,19 @@ class Build : NukeBuild
         {
             const string projectName = "AzureFunctionsTelemetryIntegrationTests";
 
+            var loggers = new List<string> { $"html;LogFileName={projectName}.html" };
+
+            if (IsServerBuild)
+            {
+                loggers.Add("GitHubActions");
+            }
+
             var dotnetTestSettings = new DotNetTestSettings()
                 .SetConfiguration(Configuration)
                 .EnableNoBuild()
                 .SetProjectFile(TestsDirectory / projectName)
                 .SetResultsDirectory(TestResultsDirectory / projectName)
-                .SetLoggers($"html;LogFileName={projectName}.html");
+                .SetLoggers(loggers);
             DotNetTest(dotnetTestSettings);
         });
 

--- a/tests/AzureFunctionsTelemetryIntegrationTests/AzureFunctionsTelemetryIntegrationTests.csproj
+++ b/tests/AzureFunctionsTelemetryIntegrationTests/AzureFunctionsTelemetryIntegrationTests.csproj
@@ -12,6 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
- Skip integration tests build target when Service Bus connection string environment variable is not set
- Document how to run integration tests