### PR TITLE
Log if Function Core Tools process has exited after kill

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -496,5 +496,8 @@ sealed class Build : NukeBuild
 
         _defaultV4Function.Kill();
         _customV4Function.Kill();
+
+        Serilog.Log.Debug("Has DefaultV4InProcessFunction exited {HasFunctionExited}", _defaultV4Function.HasExited);
+        Serilog.Log.Debug("Has CustomV4InProcessFunction exited {HasFunctionExited}", _customV4Function.HasExited);
     }
 }

--- a/src/AzureFunctionsTelemetry/ApplicationInsights/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/AzureFunctionsTelemetry/ApplicationInsights/ApplicationInsightsServiceCollectionExtensions.cs
@@ -243,7 +243,7 @@ public static class ApplicationInsightsServiceCollectionExtensions
     }
 
     /// <summary>
-    /// When the configuration APPINSIGHTS_INSTRUMENTATIONKEY / APPLICATIONINSIGHTS_CONNECTION_STRING key is not present, the Functions runtime does not
+    /// When the configuration APPLICATIONINSIGHTS_CONNECTION_STRING / APPINSIGHTS_INSTRUMENTATIONKEY key is not present, the Functions runtime does not
     /// register Application Insights with the Inversion of Control container:
     ///
     /// https://github.com/Azure/azure-functions-host/blob/7d9cd7fc69b282b2f6ce2c2ee1574a236bc69202/src/WebJobs.Script/ScriptHostBuilderExtensions.cs#L368-L372


### PR DESCRIPTION
- Log if Function Core Tools process has exited after kill. The second round of integration tests failed once because a port was still in use. I might need to wait for the process to have exited.
- Remove App Insights instrumentation key if present when running integration tests. We should only be using the Connection String
- Don't run integration tests if App Insights connection string is missing. The tests will fail.