### PR TITLE
Split VS Runner from xUnit dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,3 @@ updates:
         patterns:
           - xunit
           - xunit.analyzers
-          - xunit.runner.visualstudio


### PR DESCRIPTION
So that I can ignore the updates.