### PR TITLE
Use netstandard2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,11 +15,10 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.35" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="3.1.32" Condition="'$(TargetFramework)' == 'netstandard2.1'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="3.1.32" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.11.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.15.1" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.15.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="3.1.32" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="3.1.2" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />

--- a/samples/CustomV3InProcessFunction/Functions/Initializer/InitializerFunction.cs
+++ b/samples/CustomV3InProcessFunction/Functions/Initializer/InitializerFunction.cs
@@ -30,11 +30,8 @@ public class InitializerFunction
             _telemetryCounterInitializer.EventTelemetryCount,
             _telemetryCounterInitializer.ExceptionTelemetryCount,
             _telemetryCounterInitializer.MetricTelemetryCount,
-            _telemetryCounterInitializer.PageViewPerformanceTelemetryCount,
-            _telemetryCounterInitializer.PageViewTelemetryCount,
             _telemetryCounterInitializer.RequestTelemetryCount,
-            _telemetryCounterInitializer.TraceTelemetryCount,
-            _telemetryCounterInitializer.OtherTelemetryCount
+            _telemetryCounterInitializer.TraceTelemetryCount
         });
     }
 }

--- a/samples/CustomV3InProcessFunction/Functions/InstanceInitializer/InstanceInitializerFunction.cs
+++ b/samples/CustomV3InProcessFunction/Functions/InstanceInitializer/InstanceInitializerFunction.cs
@@ -31,11 +31,8 @@ public class InstanceInitializerFunction
             _telemetryCounterInstanceInitializer.EventTelemetryCount,
             _telemetryCounterInstanceInitializer.ExceptionTelemetryCount,
             _telemetryCounterInstanceInitializer.MetricTelemetryCount,
-            _telemetryCounterInstanceInitializer.PageViewPerformanceTelemetryCount,
-            _telemetryCounterInstanceInitializer.PageViewTelemetryCount,
             _telemetryCounterInstanceInitializer.RequestTelemetryCount,
-            _telemetryCounterInstanceInitializer.TraceTelemetryCount,
-            _telemetryCounterInstanceInitializer.OtherTelemetryCount
+            _telemetryCounterInstanceInitializer.TraceTelemetryCount
         });
     }
 }

--- a/samples/CustomV3InProcessFunction/Infrastructure/Telemetry/TelemetryCounterInitializer.cs
+++ b/samples/CustomV3InProcessFunction/Infrastructure/Telemetry/TelemetryCounterInitializer.cs
@@ -17,11 +17,8 @@ internal sealed class TelemetryCounterInitializer : ITelemetryInitializer
     public long EventTelemetryCount;
     public long ExceptionTelemetryCount;
     public long MetricTelemetryCount;
-    public long PageViewPerformanceTelemetryCount;
-    public long PageViewTelemetryCount;
     public long RequestTelemetryCount;
     public long TraceTelemetryCount;
-    public long OtherTelemetryCount;
 
     public void Initialize(ITelemetry telemetry)
     {
@@ -42,20 +39,11 @@ internal sealed class TelemetryCounterInitializer : ITelemetryInitializer
             case MetricTelemetry:
                 Interlocked.Increment(ref MetricTelemetryCount);
                 break;
-            case PageViewPerformanceTelemetry:
-                Interlocked.Increment(ref PageViewPerformanceTelemetryCount);
-                break;
-            case PageViewTelemetry:
-                Interlocked.Increment(ref PageViewTelemetryCount);
-                break;
             case RequestTelemetry:
                 Interlocked.Increment(ref RequestTelemetryCount);
                 break;
             case TraceTelemetry:
                 Interlocked.Increment(ref TraceTelemetryCount);
-                break;
-            default:
-                Interlocked.Increment(ref OtherTelemetryCount);
                 break;
         }
     }

--- a/samples/CustomV3InProcessFunction/Infrastructure/Telemetry/TelemetryCounterInstanceInitializer.cs
+++ b/samples/CustomV3InProcessFunction/Infrastructure/Telemetry/TelemetryCounterInstanceInitializer.cs
@@ -31,11 +31,8 @@ internal sealed class TelemetryCounterInstanceInitializer : ITelemetryInitialize
     public long EventTelemetryCount;
     public long ExceptionTelemetryCount;
     public long MetricTelemetryCount;
-    public long PageViewPerformanceTelemetryCount;
-    public long PageViewTelemetryCount;
     public long RequestTelemetryCount;
     public long TraceTelemetryCount;
-    public long OtherTelemetryCount;
     private const string CustomPropertyName = "NiceProp";
 
     public TelemetryCounterInstanceInitializer(string customPropertyValue)
@@ -68,20 +65,11 @@ internal sealed class TelemetryCounterInstanceInitializer : ITelemetryInitialize
             case MetricTelemetry:
                 Interlocked.Increment(ref MetricTelemetryCount);
                 break;
-            case PageViewPerformanceTelemetry:
-                Interlocked.Increment(ref PageViewPerformanceTelemetryCount);
-                break;
-            case PageViewTelemetry:
-                Interlocked.Increment(ref PageViewTelemetryCount);
-                break;
             case RequestTelemetry:
                 Interlocked.Increment(ref RequestTelemetryCount);
                 break;
             case TraceTelemetry:
                 Interlocked.Increment(ref TraceTelemetryCount);
-                break;
-            default:
-                Interlocked.Increment(ref OtherTelemetryCount);
                 break;
         }
     }

--- a/samples/CustomV4InProcessFunction/Functions/Initializer/InitializerFunction.cs
+++ b/samples/CustomV4InProcessFunction/Functions/Initializer/InitializerFunction.cs
@@ -30,11 +30,8 @@ public class InitializerFunction
             _telemetryCounterInitializer.EventTelemetryCount,
             _telemetryCounterInitializer.ExceptionTelemetryCount,
             _telemetryCounterInitializer.MetricTelemetryCount,
-            _telemetryCounterInitializer.PageViewPerformanceTelemetryCount,
-            _telemetryCounterInitializer.PageViewTelemetryCount,
             _telemetryCounterInitializer.RequestTelemetryCount,
-            _telemetryCounterInitializer.TraceTelemetryCount,
-            _telemetryCounterInitializer.OtherTelemetryCount
+            _telemetryCounterInitializer.TraceTelemetryCount
         });
     }
 }

--- a/samples/CustomV4InProcessFunction/Functions/InstanceInitializer/InstanceInitializerFunction.cs
+++ b/samples/CustomV4InProcessFunction/Functions/InstanceInitializer/InstanceInitializerFunction.cs
@@ -31,11 +31,8 @@ public class InstanceInitializerFunction
             _telemetryCounterInstanceInitializer.EventTelemetryCount,
             _telemetryCounterInstanceInitializer.ExceptionTelemetryCount,
             _telemetryCounterInstanceInitializer.MetricTelemetryCount,
-            _telemetryCounterInstanceInitializer.PageViewPerformanceTelemetryCount,
-            _telemetryCounterInstanceInitializer.PageViewTelemetryCount,
             _telemetryCounterInstanceInitializer.RequestTelemetryCount,
-            _telemetryCounterInstanceInitializer.TraceTelemetryCount,
-            _telemetryCounterInstanceInitializer.OtherTelemetryCount
+            _telemetryCounterInstanceInitializer.TraceTelemetryCount
         });
     }
 }

--- a/samples/CustomV4InProcessFunction/Infrastructure/Telemetry/TelemetryCounterInitializer.cs
+++ b/samples/CustomV4InProcessFunction/Infrastructure/Telemetry/TelemetryCounterInitializer.cs
@@ -17,11 +17,8 @@ internal sealed class TelemetryCounterInitializer : ITelemetryInitializer
     public long EventTelemetryCount;
     public long ExceptionTelemetryCount;
     public long MetricTelemetryCount;
-    public long PageViewPerformanceTelemetryCount;
-    public long PageViewTelemetryCount;
     public long RequestTelemetryCount;
     public long TraceTelemetryCount;
-    public long OtherTelemetryCount;
 
     public void Initialize(ITelemetry telemetry)
     {
@@ -42,20 +39,11 @@ internal sealed class TelemetryCounterInitializer : ITelemetryInitializer
             case MetricTelemetry:
                 Interlocked.Increment(ref MetricTelemetryCount);
                 break;
-            case PageViewPerformanceTelemetry:
-                Interlocked.Increment(ref PageViewPerformanceTelemetryCount);
-                break;
-            case PageViewTelemetry:
-                Interlocked.Increment(ref PageViewTelemetryCount);
-                break;
             case RequestTelemetry:
                 Interlocked.Increment(ref RequestTelemetryCount);
                 break;
             case TraceTelemetry:
                 Interlocked.Increment(ref TraceTelemetryCount);
-                break;
-            default:
-                Interlocked.Increment(ref OtherTelemetryCount);
                 break;
         }
     }

--- a/samples/CustomV4InProcessFunction/Infrastructure/Telemetry/TelemetryCounterInstanceInitializer.cs
+++ b/samples/CustomV4InProcessFunction/Infrastructure/Telemetry/TelemetryCounterInstanceInitializer.cs
@@ -31,11 +31,8 @@ internal sealed class TelemetryCounterInstanceInitializer : ITelemetryInitialize
     public long EventTelemetryCount;
     public long ExceptionTelemetryCount;
     public long MetricTelemetryCount;
-    public long PageViewPerformanceTelemetryCount;
-    public long PageViewTelemetryCount;
     public long RequestTelemetryCount;
     public long TraceTelemetryCount;
-    public long OtherTelemetryCount;
     private const string CustomPropertyName = "NiceProp";
 
     public TelemetryCounterInstanceInitializer(string customPropertyValue)
@@ -68,20 +65,11 @@ internal sealed class TelemetryCounterInstanceInitializer : ITelemetryInitialize
             case MetricTelemetry:
                 Interlocked.Increment(ref MetricTelemetryCount);
                 break;
-            case PageViewPerformanceTelemetry:
-                Interlocked.Increment(ref PageViewPerformanceTelemetryCount);
-                break;
-            case PageViewTelemetry:
-                Interlocked.Increment(ref PageViewTelemetryCount);
-                break;
             case RequestTelemetry:
                 Interlocked.Increment(ref RequestTelemetryCount);
                 break;
             case TraceTelemetry:
                 Interlocked.Increment(ref TraceTelemetryCount);
-                break;
-            default:
-                Interlocked.Increment(ref OtherTelemetryCount);
                 break;
         }
     }

--- a/src/AzureFunctionsTelemetry/ApplicationInsights/ApplicationInsightsServiceCollectionExtensions.cs
+++ b/src/AzureFunctionsTelemetry/ApplicationInsights/ApplicationInsightsServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ public static class ApplicationInsightsServiceCollectionExtensions
             return services;
         }
 
-#pragma warning disable CA1510 // I still have to support netstandard 2.1
+#pragma warning disable CA1510 // I still have to support netstandard 2.0
         if (config == null)
         {
             throw new ArgumentNullException(nameof(config));
@@ -47,7 +47,7 @@ public static class ApplicationInsightsServiceCollectionExtensions
         }
 #pragma warning restore CA1510
 
-        if (!string.IsNullOrWhiteSpace(config.ApplicationName))
+        if (config.ApplicationName != null && !string.IsNullOrWhiteSpace(config.ApplicationName))
         {
             var applicationVersion = GetAssemblyInformationalVersion(config.TypeFromEntryAssembly);
             var applicationDescriptor = new ApplicationDescriptor(config.ApplicationName, applicationVersion);
@@ -208,7 +208,7 @@ public static class ApplicationInsightsServiceCollectionExtensions
                         customProcessors.Insert(0, serviceBusTriggerFilter);
                     }
 
-                    if (!string.IsNullOrWhiteSpace(lightOptions.HealthCheckFunctionName))
+                    if (lightOptions.HealthCheckFunctionName != null && !string.IsNullOrWhiteSpace(lightOptions.HealthCheckFunctionName))
                     {
                         var healthRequestFilter = new HealthRequestFilter(
                             customProcessors.First(),

--- a/src/AzureFunctionsTelemetry/ApplicationInsights/DuplicateExceptionsFilter.cs
+++ b/src/AzureFunctionsTelemetry/ApplicationInsights/DuplicateExceptionsFilter.cs
@@ -16,7 +16,7 @@ internal class DuplicateExceptionsFilter : ITelemetryProcessor
     {
         if (item is ExceptionTelemetry exceptionTelemetry)
         {
-            if (TelemetryHelper.TryGetCategory(exceptionTelemetry, out var category))
+            if (TelemetryHelper.TryGetCategory(exceptionTelemetry, out var category) && category != null)
             {
                 if (StringHelper.IsSame(FunctionRuntimeCategory.HostResults, category))
                 {

--- a/src/AzureFunctionsTelemetry/ApplicationInsights/FunctionExecutionTracesFilter.cs
+++ b/src/AzureFunctionsTelemetry/ApplicationInsights/FunctionExecutionTracesFilter.cs
@@ -32,10 +32,20 @@ internal class FunctionExecutionTracesFilter : ITelemetryProcessor
         _next.Process(item);
     }
 
-    private static bool IsServiceBusBindingMessageErrorProcessingTrace(TraceTelemetry trace) =>
-        trace.SeverityLevel == SeverityLevel.Error &&
-        TelemetryHelper.TryGetCategory(trace, out var category) &&
-        StringHelper.IsSame(FunctionRuntimeCategory.ServiceBusListener, category) &&
-        !string.IsNullOrEmpty(trace.Message) &&
-        trace.Message.StartsWith("Message processing error", StringComparison.OrdinalIgnoreCase);
+    private static bool IsServiceBusBindingMessageErrorProcessingTrace(TraceTelemetry trace)
+    {
+        if (trace.SeverityLevel != SeverityLevel.Error)
+        {
+            return false;
+        }
+
+        if (!TelemetryHelper.TryGetCategory(trace, out var category) || category == null)
+        {
+            return false;
+        }
+
+        return StringHelper.IsSame(FunctionRuntimeCategory.ServiceBusListener, category) &&
+               !string.IsNullOrEmpty(trace.Message) &&
+               trace.Message.StartsWith("Message processing error", StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/AzureFunctionsTelemetry/ApplicationInsights/TelemetryHelper.cs
+++ b/src/AzureFunctionsTelemetry/ApplicationInsights/TelemetryHelper.cs
@@ -1,41 +1,62 @@
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Azure.WebJobs.Logging;
 
 namespace Gabo.AzureFunctionsTelemetry.ApplicationInsights;
 
 internal static class TelemetryHelper
 {
-    public static bool TryGetCategory(ISupportProperties telemetry, [NotNullWhen(true)] out string? category) =>
+    public static bool TryGetCategory(ISupportProperties telemetry, out string? category) =>
         telemetry.Properties.TryGetValue(LogConstants.CategoryNameKey, out category);
 
-    private static bool TryGetEventId(ISupportProperties telemetry, [NotNullWhen(true)] out string? eventId) =>
+    private static bool TryGetEventId(ISupportProperties telemetry, out string? eventId) =>
         telemetry.Properties.TryGetValue(LogConstants.EventIdKey, out eventId);
 
-    private static bool TryGetEventName(ISupportProperties telemetry, [NotNullWhen(true)] out string? eventName) =>
+    private static bool TryGetEventName(ISupportProperties telemetry, out string? eventName) =>
         telemetry.Properties.TryGetValue(LogConstants.EventNameKey, out eventName);
 
     public static bool IsFunctionStartedTelemetry(ISupportProperties trace) =>
         HasFunctionStartedEventId(trace) && HasFunctionStartedEventName(trace);
 
-    private static bool HasFunctionStartedEventId(ISupportProperties telemetry) =>
-        TryGetEventId(telemetry, out var eventId) &&
-        StringHelper.IsSame(FunctionRuntimeEventId.FunctionStarted, eventId);
+    private static bool HasFunctionStartedEventId(ISupportProperties telemetry)
+    {
+        if (!TryGetEventId(telemetry, out var eventId) || eventId == null)
+        {
+            return false;
+        }
 
-    private static bool HasFunctionStartedEventName(ISupportProperties telemetry) =>
-        TryGetEventName(telemetry, out var eventName) &&
-        StringHelper.IsSame(FunctionRuntimeEventName.FunctionStarted, eventName);
+        return StringHelper.IsSame(FunctionRuntimeEventId.FunctionStarted, eventId);
+    }
+
+    private static bool HasFunctionStartedEventName(ISupportProperties telemetry)
+    {
+        if (!TryGetEventName(telemetry, out var eventName) || eventName == null)
+        {
+            return false;
+        }
+
+        return StringHelper.IsSame(FunctionRuntimeEventName.FunctionStarted, eventName);
+    }
 
     public static bool IsFunctionCompletedTelemetry(ISupportProperties telemetry) =>
         HasFunctionCompletedEventId(telemetry) && HasFunctionCompletedEventName(telemetry);
 
-    private static bool HasFunctionCompletedEventName(ISupportProperties telemetry) =>
-        TryGetEventName(telemetry, out var eventName) &&
-        StringHelper.IsSame(FunctionRuntimeEventName.FunctionCompleted, eventName);
+    private static bool HasFunctionCompletedEventName(ISupportProperties telemetry)
+    {
+        if (!TryGetEventName(telemetry, out var eventName) || eventName == null)
+        {
+            return false;
+        }
 
-    private static bool HasFunctionCompletedEventId(ISupportProperties telemetry) =>
-        TryGetEventId(telemetry, out var eventId) &&
-        (
-            StringHelper.IsSame(FunctionRuntimeEventId.FunctionCompletedSucceeded, eventId) ||
-            StringHelper.IsSame(FunctionRuntimeEventId.FunctionCompletedFailed, eventId)
-        );
+        return StringHelper.IsSame(FunctionRuntimeEventName.FunctionCompleted, eventName);
+    }
+
+    private static bool HasFunctionCompletedEventId(ISupportProperties telemetry)
+    {
+        if (!TryGetEventId(telemetry, out var eventId) || eventId == null)
+        {
+            return false;
+        }
+
+        return StringHelper.IsSame(FunctionRuntimeEventId.FunctionCompletedSucceeded, eventId) ||
+               StringHelper.IsSame(FunctionRuntimeEventId.FunctionCompletedFailed, eventId);
+    }
 }

--- a/src/AzureFunctionsTelemetry/AzureFunctionsTelemetry.csproj
+++ b/src/AzureFunctionsTelemetry/AzureFunctionsTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
I shouldn't have used .NET Standard 2.1 to start with. See [The future of .NET Standard](https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/) and [.NET Standard](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0).